### PR TITLE
Firefox seems to be only browser that defaults to `StyleWithCSS == true`

### DIFF
--- a/scripts/etch.js
+++ b/scripts/etch.js
@@ -275,10 +275,10 @@
       try {
         document.execCommand('StyleWithCSS', false, false);
       }
-      catch (e) {
+      catch (err) {
         // expecting to just eat IE8 error, but if different error, rethrow
-        if (e.message !== "Invalid argument.") {
-          throw e;
+        if (err.message !== "Invalid argument.") {
+          throw err;
         }
       }
 


### PR DESCRIPTION
so explicitly disable StyleWithCSS for markup consistency across browsers
(and made sure it didn't break on IE8).
