### PR TITLE
Add callback that can tweak link URL before it's added to the DOM.

### DIFF
--- a/scripts/etch.js
+++ b/scripts/etch.js
@@ -29,7 +29,7 @@
         } else {
             return "http://" + url;
         }
-    }
+    };
 
     models.Editor = Backbone.Model;
 


### PR DESCRIPTION
Without this feature, if someone adds a link "abc.com", the url won't be valid since they didn't type http:// in front of it.

Made this a callback so an application using etch can define this any way they need to, or decide not to use by setting etch.enhanceURL to undefined.

Hey Josh,

Also, I'm wondering if an "etch.options" namespace should be created to start adding various options there instead of adding them on "etch" itself.  I can envision new options growing over time.

-Bri
