### PR TITLE
Add init and remove events

### DIFF
--- a/scripts/etch.js
+++ b/scripts/etch.js
@@ -247,6 +247,7 @@
     // you use to initialize editing 
     editableInit: function(e) {
       e.stopPropagation();
+      var self = this;
       var target = e.target || e.srcElement;
       var $editable = $(target).etchFindEditable();
       $editable.attr('contenteditable', true);
@@ -298,6 +299,8 @@
         }
       }
 
+      self.model && self.model.trigger('etch:init');
+
       // listen for mousedowns that are not coming from the editor
       // and close the editor
       $('body').bind('mousedown.editor', function(e) {
@@ -305,8 +308,8 @@
         var target = e.target || e.srcElement;
         if ($(target).not('.etch-editor-panel, .etch-editor-panel *, .etch-image-tools, .etch-image-tools *').size()) {
           // remove editor
+          self.model && self.model.trigger('etch:remove');
           $editor.remove();
-                    
                     
           if (models.EditableImage) {
             // unblind the image-tools if the editor isn't active


### PR DESCRIPTION
This patch adds `etch:init` and `etch:remove` events which are triggered after `editableInit` and before removing.

Use case: the editable area has a `draggable` attribute which needs to be unset during editing, and put back when done.

Alternatively the events could be fired on the target element instead of the model, but since etch is already tightly coupled to Backbone I thought I'd follow that path.
