### PR TITLE
Remove link underline if we click cancel

### DIFF
--- a/scripts/etch.js
+++ b/scripts/etch.js
@@ -145,6 +145,10 @@
       // Override this function if you want to implement a custom UI.
         
       var url = prompt('Enter a url', 'http://');
+	    
+      if (null === url) {
+          return;
+      }
         
       // Ensure a new link URL starts with http:// or https:// 
       // before it's added to the DOM.


### PR DESCRIPTION
When we try to create link but in last moment click "cancel", underline will be under selected text.
Video: https://i.gyazo.com/2976b393959410ef700ad2fb9e36875e.mp4